### PR TITLE
[ES-242] Handling expired refresh token

### DIFF
--- a/src/utils/apis/APILinks.js
+++ b/src/utils/apis/APILinks.js
@@ -1,5 +1,5 @@
-export const recruitmentServiceBasicAPILink = "http://localhost:8080"
-// export const recruitmentServiceBasicAPILink = "https://recruitment-service-estella.herokuapp.com"
+// export const recruitmentServiceBasicAPILink = "http://localhost:8080"
+export const recruitmentServiceBasicAPILink = "https://recruitment-service-estella.herokuapp.com"
 
 export const meetingOrganizerLink = "https://meeting-organizer-estella.herokuapp.com/"
 

--- a/src/utils/apis/APILinks.js
+++ b/src/utils/apis/APILinks.js
@@ -1,5 +1,5 @@
-//export const recruitmentServiceBasicAPILink = "http://localhost:8080"
-export const recruitmentServiceBasicAPILink = "https://recruitment-service-estella.herokuapp.com"
+export const recruitmentServiceBasicAPILink = "http://localhost:8080"
+// export const recruitmentServiceBasicAPILink = "https://recruitment-service-estella.herokuapp.com"
 
 export const meetingOrganizerLink = "https://meeting-organizer-estella.herokuapp.com/"
 

--- a/src/utils/apis/JwtAPI.js
+++ b/src/utils/apis/JwtAPI.js
@@ -1,5 +1,4 @@
 import {recruitmentServiceBasicAPILink} from "./APILinks";
-import {loginAPI} from "./LoginAPI";
 import {jwtUtils} from "../jwt/jwtUtils";
 import {checkedFetch} from "../chekedFetch";
 
@@ -12,11 +11,6 @@ export const jwtAPI = {
                 headers: {
                     "x-jwt": refreshToken
                 }
-            }
-        ).then(
-            response => {
-                localStorage.setItem(loginAPI.authTokenStorageKey, response.headers.get(loginAPI.authTokenKey));
-                return response;
             }
         )
 }

--- a/src/utils/jwt/jwtUtils.js
+++ b/src/utils/jwt/jwtUtils.js
@@ -2,6 +2,7 @@ import {validateSchema} from "../schemas/validateSchema";
 import {tokenPayloadSchema} from "../schemas/tokenPayloadSchema";
 import {loginAPI} from "../apis/LoginAPI";
 import {jwtAPI} from "../apis/JwtAPI";
+import Swal from "sweetalert2";
 
 export const jwtUtils = {
     jwtHeaderKey: "x-jwt",
@@ -36,6 +37,23 @@ export const jwtUtils = {
         const refreshToken = jwtUtils.getRefreshToken()
         if(userId && refreshToken)
             return jwtAPI.refreshToken(userId, refreshToken)
+                .then(response => {
+                    localStorage.setItem(loginAPI.authTokenStorageKey, response.headers.get(loginAPI.authTokenKey));
+                    localStorage.setItem(loginAPI.refreshTokenStorageKey, response.headers.get(loginAPI.refreshTokenKey));
+                    return response;
+                })
+                .catch(() => {
+                    localStorage.removeItem(loginAPI.authTokenStorageKey)
+                    localStorage.removeItem(loginAPI.refreshTokenStorageKey)
+                    Swal.fire({
+                        text: "Your session expired. We will take you to our login page!",
+                        icon: "warning"
+                    })
+                    .then(() => {
+                        window.history.pushState({urlPath: "/#/login"}, "", "/#/login")
+                        window.location.reload()
+                    })
+                })
     },
 
     tokenSplitter: (token) => {

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -56,7 +56,7 @@ const routes = ([reload, setReload]) => [
     createRoute("*", <div>Page</div>)
 ]
 
-export const getRoutes = ({reload, setReload}) => {
+export const getRoutes = ([reload, setReload]) => {
     return routes([reload, setReload]).map((route, idx) => {
         return (
             <Route exact path={route.path} key={`${idx}`}>

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -56,7 +56,7 @@ const routes = ([reload, setReload]) => [
     createRoute("*", <div>Page</div>)
 ]
 
-export const getRoutes = ([reload, setReload]) => {
+export const getRoutes = ({reload, setReload}) => {
     return routes([reload, setReload]).map((route, idx) => {
         return (
             <Route exact path={route.path} key={`${idx}`}>


### PR DESCRIPTION
Lepsza obsługa tokenu odswiezajacego - odświeżanie refreshToken (wymaga brancha ES-242 z RS), przekierowanie na stronę logowania po nieudanym refreshu tokena